### PR TITLE
Ensure MongoDB connection before server start

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,17 @@ app.get('/', (req, res) => {
 
 // Serveur
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-    console.log(`🚀 Serveur absurde lancé sur le port ${PORT}`);
-});
+
+async function startServer() {
+    try {
+        await connectDB();
+        app.listen(PORT, () => {
+            console.log(`🚀 Serveur absurde lancé sur le port ${PORT}`);
+        });
+    } catch (err) {
+        console.error('💥 Impossible de démarrer le serveur :', err);
+        process.exit(1);
+    }
+}
+
+startServer();


### PR DESCRIPTION
## Summary
- await MongoDB connection before starting Express server
- add error handling to prevent silent startup on connection failure

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68924b903918832094d62a695d30c763